### PR TITLE
Revert "Added carrierwave gem as Heroku crashes without"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ gem 'jquery-ui-rails'
 gem "algoliasearch-rails"
 gem 'chartjs-ror'
 gem "pundit"
-gem 'carrierwave', '~> 1.0'
 
 
 group :development, :test do


### PR DESCRIPTION
Reverts pavlad/simplify-project-management#85